### PR TITLE
fix: fs-extra no longer exports existsSync

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -5,7 +5,8 @@ import { cleanUrl, isDirEmpty, loadEnv } from './utils'
 import { htmlFilter } from './utils/createHtmlFilter'
 import { mergeConfig } from 'vite'
 import { parse } from 'node-html-parser'
-import { existsSync, readFile, move, remove } from 'fs-extra'
+import fsExtra from 'fs-extra'
+const { pathExistsSync, readFile, move, remove } = fsExtra
 import { resolve, dirname, basename } from 'pathe'
 import fg from 'fast-glob'
 import consola from 'consola'
@@ -270,7 +271,7 @@ export function getHtmlPath(page: PageOption, root: string) {
 }
 
 export async function readHtml(path: string) {
-  if (!existsSync(path)) {
+  if (!pathExistsSync(path)) {
     throw new Error(`html is not exist in ${path}`)
   }
   return await readFile(path).then((buffer) => buffer.toString())

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -1,7 +1,8 @@
 import { expand } from 'dotenv-expand'
 import dotenv from 'dotenv'
 import { join, dirname } from 'pathe'
-import { existsSync, readFileSync, statSync, readdir } from 'fs-extra'
+import fsExtra from 'fs-extra'
+const { pathExistsSync, readFileSync, statSync, readdir } = fsExtra
 
 export function loadEnv(
   mode: string,
@@ -59,7 +60,7 @@ export function lookupFile(
 ): string | undefined {
   for (const format of formats) {
     const fullPath = join(dir, format)
-    if (existsSync(fullPath) && statSync(fullPath).isFile()) {
+    if (pathExistsSync(fullPath) && statSync(fullPath).isFile()) {
       return pathOnly ? fullPath : readFileSync(fullPath, 'utf-8')
     }
   }


### PR DESCRIPTION
With the current 3.0.1 release I encounter this error:

```
failed to load config from /home/m/nrf-asset-tracker/app-aws/vite.config.ts
error when starting dev server:
file:///home/m/nrf-asset-tracker/app-aws/node_modules/vite-plugin-html/dist/index.mjs:6
import { readFileSync, existsSync, statSync, readdir, move, remove, readFile } from 'fs-extra';
                       ^^^^^^^^^^
SyntaxError: Named export 'existsSync' not found. The requested module 'fs-extra' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'fs-extra';
const { readFileSync, existsSync, statSync, readdir, move, remove, readFile } = pkg;

    at ModuleJob._instantiate (node:internal/modules/esm/module_job:127:21)
    at async ModuleJob.run (node:internal/modules/esm/module_job:191:5)
    at async Promise.all (index 0)
    at async ESMLoader.import (node:internal/modules/esm/loader:337:24)
    at async importModuleDynamicallyWrapper (node:internal/vm/module:437:15)
    at async loadConfigFromFile (/home/m/nrf-asset-tracker/app-aws/node_modules/vite/dist/node/chunks/dep-f5552faa.js:75080:31)
    at async resolveConfig (/home/m/nrf-asset-tracker/app-aws/node_modules/vite/dist/node/chunks/dep-f5552faa.js:74656:28)
    at async createServer (/home/m/nrf-asset-tracker/app-aws/node_modules/vite/dist/node/chunks/dep-f5552faa.js:60326:20)
    at async CAC.<anonymous> (/home/m/nrf-asset-tracker/app-aws/node_modules/vite/dist/node/cli.js:688:24)
```