### PR TITLE
fix: fix path rewriting in history mode support

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -340,7 +340,7 @@ function createRewire(
       const isApiUrl = proxyUrlKeys.some((item) =>
         pathname.startsWith(path.resolve(baseUrl, item)),
       )
-      return isApiUrl ? excludeBaseUrl : template
+      return isApiUrl ? parsedUrl.path : template
     },
   }
 }


### PR DESCRIPTION
Hi @anncwb !

This fixes a problem in which the API was not called correctly because `excludeBaseUrl` did not contain a query string.

related issue #38