### PR TITLE
fix: do not remove comment when there is an entry option

### DIFF
--- a/packages/core/src/__tests__/html.spec.ts
+++ b/packages/core/src/__tests__/html.spec.ts
@@ -58,4 +58,24 @@ describe('function test.', () => {
 </html>
 `)
   })
+
+  test('renderHtml must keep comment with entry.', async () => {
+    const content = await renderHtml(`
+<!DOCTYPE html>
+<html>
+<!--comment-->
+</html>
+`, {
+  injectOptions: {},
+  viteConfig: {} as any,
+  env: {},
+  entry: 'fake'
+},)
+  expect(content).toEqual(`
+<!DOCTYPE html>
+<html>
+<!--comment-->
+</html>
+`)
+  })
 })

--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -3,7 +3,7 @@ import type { InjectOptions, PageOption, Pages, UserOptions } from './typing'
 import { render } from 'ejs'
 import { isDirEmpty, loadEnv } from './utils'
 import { normalizePath } from 'vite'
-import { parse } from 'node-html-parser'
+import parse from 'node-html-parser'
 import fs from 'fs-extra'
 import path from 'pathe'
 import fg from 'fast-glob'
@@ -255,7 +255,7 @@ export function removeEntryScript(html: string, verbose = false) {
     return html
   }
 
-  const root = parse(html)
+  const root = parse(html, { comment: true })
   const scriptNodes = root.querySelectorAll('script[type=module]') || []
   const removedNode: string[] = []
   scriptNodes.forEach((item) => {
@@ -268,6 +268,7 @@ export function removeEntryScript(html: string, verbose = false) {
       removedNode.toString(),
     )} is deleted. You may also delete it from the index.html.
         `)
+  consola.warn(root.toString())
   return root.toString()
 }
 


### PR DESCRIPTION
The problem solved is that node-html-parser used when there is an entry option remove comments by default.
If we want to keep comments (for SSR for example <!--ssr-outlet--> as described [here](https://vitejs.dev/guide/ssr.html))

We simply call parse with {comments: true} option, comments will be removed by the minifier if needed in the next step