### PR TITLE
feat: support RegExp type proxy settings

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -338,6 +338,7 @@ function createRewire(
         return template
       }
       const isApiUrl = proxyUrlKeys.some((item) =>
+        item.startsWith('^') && new RegExp(item).test(pathname) ||
         pathname.startsWith(path.resolve(baseUrl, item)),
       )
       return isApiUrl ? excludeBaseUrl : template


### PR DESCRIPTION
According to the [Vite's docs](https://vitejs.dev/config/server-options.html#server-proxy), vite allows user to create `RegExp` type proxy rules, we should support it too.

> If the key starts with ^, it will be interpreted as a RegExp.