### PR TITLE
fix mpa configuration when the base was not empty

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -326,7 +326,7 @@ function createRewire(
   proxyUrlKeys: string[],
 ) {
   return {
-    from: new RegExp(`^/${reg}*`),
+    from: new RegExp(`^${baseUrl.endsWith('/')?baseUrl:baseUrl+'/'}${reg}*`),
     to({ parsedUrl }: any) {
       const pathname: string = parsedUrl.pathname
 


### PR DESCRIPTION
配置中包含base的情况下，多页配置就会失效。因为createRewire这里生成的正则没有适配base不为空的情况，申请合入。