### PR TITLE
fix: multi-page different usage of `filename` and `template`

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -295,7 +295,8 @@ export function getPageConfig(
   }
 
   const page = pages.filter((page) => {
-    return path.resolve('/' + page.template) === path.resolve('/' + htmlName)
+    // Path to specified file path, if not to template path
+    return path.resolve('/' + page.filename || page.template) === path.resolve('/' + htmlName)
   })?.[0]
   return page ?? defaultPageOption ?? undefined
 }
@@ -332,7 +333,8 @@ function createRewire(
 
       const excludeBaseUrl = pathname.replace(baseUrl, '/')
 
-      const template = path.resolve(baseUrl, page.template)
+      // Path to specified file path, if not to template path
+      const template = path.resolve(baseUrl, page.filename || page.template)
 
       if (excludeBaseUrl === '/') {
         return template


### PR DESCRIPTION
Hello,

I am currently trying Multi-Entrypoints with multi Page templates.

Unfortunately I found that something is difficult to get running. After I had it then however, I had to determine... That certain things in the Plugin are not correctly assigned.

This is about the two properties `template` and `filename`. According to the code there seems to be inconsistencies. When and where the `template` or `filename` is accessed, is somewhat inconsistent.

I have expanded the places in this PR, but somehow there seems to be an inconsistency in it.

https://github.com/vbenjs/vite-plugin-html/blob/841d4ef04c3cf5ff0d4339350ae336aa83aa70ed/packages/core/src/htmlPlugin.ts#L297-L299

https://github.com/vbenjs/vite-plugin-html/blob/841d4ef04c3cf5ff0d4339350ae336aa83aa70ed/packages/core/src/htmlPlugin.ts#L322-L346
---
What is this? If I replace the `template` there with `filename`, this then works and copies the HTML files to the root level, where folder structure is needed.
https://github.com/vbenjs/vite-plugin-html/blob/841d4ef04c3cf5ff0d4339350ae336aa83aa70ed/packages/core/src/htmlPlugin.ts#L120-L164

--- 
My Example:

**Config**
```js
{
  minify: false,
  pages: [
    {
      entry: './main.js',
      filename: 'src/banners/300x250/index.html',
      template: 'banners/300x250/index.html',
      injectOptions: {
        data: {
          title: 'Index'
        }
      }
    },
    {
      entry: './main.js',
      filename: 'src/banners/800x250/index.html',
      template: 'banners/800x250/index.html',
      injectOptions: {
        data: {
          title: 'Index'
        }
      }
    }
  ]
}
```
1. in dev the redirection to filename is correct. (e.g. http://localhost:3000/banners/300x250/index.html)
2. in the build as long as `closeBundle` is not adjusted, I get now the output in the build, unfortunately I do not know how to remove the `src` path in the generated files. (Background: Everything that is programmed is in the `src` folder). 

![image](https://github.com/vbenjs/vite-plugin-html/assets/8287751/de12acdd-8587-460b-a972-4e35db4dd44d)


