### PR TITLE
fix: request proxy url the query does not take effect

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -328,7 +328,7 @@ function createRewire(
   return {
     from: new RegExp(`^/${reg}*`),
     to({ parsedUrl }: any) {
-      const pathname: string = parsedUrl.pathname
+      const pathname: string = parsedUrl.path
 
       const excludeBaseUrl = pathname.replace(baseUrl, '/')
 


### PR DESCRIPTION
地址栏请求vite proxy代理地址，vite-plugin-html会把query信息过滤掉