### PR TITLE
docs: remove viteNext user config property from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ export default defineConfig({
           },
         ],
       },
-      /**
-       * If you are using vite that version higher than 5.0.0-beta.13, you can set viteNext to true to align vite's config
-       */
-      viteNext: false,
     }),
   ],
 })
@@ -161,7 +157,6 @@ export default defineConfig({
 | inject    | `InjectOptions`          | -             | Data injected into HTML                           |
 | minify    | `boolean｜MinifyOptions` | -             | whether to compress html                          |
 | pages     | `PageOption`             | -             | Multi-page configuration                          |
-| viteNext  | `boolean`                | false         | set to true to support the latest version of vite |
 
 ### InjectOptions
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -84,10 +84,6 @@ export default defineConfig({
           },
         ],
       },
-      /**
-       * 如果你使用的 vite 版本高于 5.0.0-beta.13，可以将 viteNext 设置为 true 来进行兼容
-       */
-      viteNext: false,
     }),
   ],
 })
@@ -163,7 +159,6 @@ export default defineConfig({
 | inject   | `InjectOptions`          | -             | 注入 HTML 的数据                |
 | minify   | `boolean｜MinifyOptions` | -             | 是否压缩 html                   |
 | pages    | `PageOption`             | -             | 多页配置                        |
-| viteNext | `boolean`                | false         | 用于开启是否兼容最新版本的 vite |
 
 ### InjectOptions
 


### PR DESCRIPTION
Since #140, this config property `viteNext` has not existed in the code. This PR removes mentions of it to bring the README files up-to-date.

After this, I believe vite-plugin-html will be ready for a swift release to get rid of those pesky warnings in Vite 5.