### PR TITLE
Remove url.parse / 删除已弃用的对 url.parse 的调用

### DIFF
--- a/packages/playground/basic/server.js
+++ b/packages/playground/basic/server.js
@@ -1,11 +1,10 @@
 const http = require('http')
-const url = require('url')
+const { URL } = require('url')
 
 const port = 8080
 
 const server = http.createServer((req, res) => {
-  const urlObject = url.parse(req.url)
-  const { pathname } = urlObject
+  const { pathname } = new URL(req.url)
 
   // api开头的是API请求
   if (pathname.startsWith('/api')) {


### PR DESCRIPTION
这个问题处理了NodeJS中的下列弃用警告，通过使用URL类而不是全局解析方法来处理。两者都有pathname属性，这是这里所需的。(This handles the following deprecation in NodeJS by using the URL class rather than the global `parse` method which both have the `pathname` attribute which is what is required here.)

> [DEP0169] DeprecationWarning: url.parse() behavior is not standardized and prone to errors that have security implications. Use the WHATWG URL API instead. CVEs are not issued for url.parse() vulnerabilities.

修复 #149 (Fixes #149)