### PR TITLE
fix: rewrite rules for RegExp proxy urls

### DIFF
--- a/packages/core/src/htmlPlugin.ts
+++ b/packages/core/src/htmlPlugin.ts
@@ -355,8 +355,10 @@ function createRewire(
         return template
       }
       const isApiUrl = proxyUrlKeys.some((item) =>
-        pathname.startsWith(path.resolve(baseUrl, item)),
-      )
+		    item[0] === '^'
+			    ? new RegExp(item).test(pathname)
+			    : pathname.startsWith(path.resolve(baseUrl, item))
+	    );
       return isApiUrl ? parsedUrl.path : template
     },
   }


### PR DESCRIPTION
Hi, 
I'm using RegExp for Vite proxy, official documentation: https://vitejs.dev/config/server-options.html#server-proxy
This code implements support for this feature (you can see original code in Vite package: https://github.com/vitejs/vite/blob/2c64267a82f1dfe703268fd5d8b1826e9bb457d5/packages/vite/src/node/server/middlewares/proxy.ts#L175-L180 )
